### PR TITLE
variable name conflicts with preprocessor definition

### DIFF
--- a/udt_c_connector.h
+++ b/udt_c_connector.h
@@ -12,6 +12,7 @@ extern "C" {
 // that wraps htons and is called _htons, which makes Go happy.
 uint16_t _htons(uint16_t hostshort);
 
+#undef ERROR
 extern const int ERROR;
 extern const UDTSOCKET INVALID_SOCK;
 


### PR DESCRIPTION
Seems like ERROR defined as macro in windows case